### PR TITLE
feat(odoo-api): parametrize production order and picking locations

### DIFF
--- a/odoo-api/pyproject.toml
+++ b/odoo-api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "odoo-api"
-version = "3.3.0"
+version = "3.4.0"
 description = "Odoo xmlrpc api wrapper"
 authors = [{ name = "bastianibanez", email = "bastian.miba@gmail.com" }]
 readme = "README.md"

--- a/odoo-api/src/odoo_api/product.py
+++ b/odoo-api/src/odoo_api/product.py
@@ -1170,15 +1170,17 @@ class OdooProduct(OdooAPI):
             stock_transfer_data["message"] = f"Error al crear el movimiento de stock"
             return stock_transfer_data
 
-    def create_product_picking(self, product_data, picking_quantity):
+    def create_product_picking(
+        self,
+        product_data,
+        picking_quantity,
+        source_location_id: int = 8,
+        destination_location_id: int = 20,
+        picking_type_id: int = 5,
+    ):
         """
         Crea una transferencia interna de picking para un producto específico.
         """
-        # Hardcoded values
-        source_location_id = 8
-        destination_location_id = 20
-        picking_type_id_internal = 5  # ID para 'transferencia-interna'
-
         picking_data = {
             "status": None,
             "message": None,
@@ -1192,7 +1194,7 @@ class OdooProduct(OdooAPI):
         picking_vals = {
             "location_id": source_location_id,
             "location_dest_id": destination_location_id,
-            "picking_type_id": picking_type_id_internal,
+            "picking_type_id": picking_type_id,
         }
 
         try:
@@ -1223,6 +1225,10 @@ class OdooProduct(OdooAPI):
     def create_single_production_order(
         self, product_sku: str, product_qty: int, picking_qty: int,
         origin_suffix: str = None, debug=False,
+        location_dest_id: int = 8,
+        picking_source_location_id: int | None = None,
+        picking_destination_location_id: int = 20,
+        picking_type_id: int = 5,
     ):
         """
         Crea una orden de poducción en Odoo basándose en el DataFrame de ordenes de producción.
@@ -1284,7 +1290,7 @@ class OdooProduct(OdooAPI):
         production_order_vals = {
             "product_id": production_order_data["product_data"]["product_id"],
             "product_qty": product_qty,
-            "location_dest_id": 8,
+            "location_dest_id": location_dest_id,
         }
         # Solo agregar bom_id si existe
         if bom_data["bom_id"] is not None:
@@ -1345,7 +1351,13 @@ class OdooProduct(OdooAPI):
         # 5. Crear el picking
         if debug:
             print(f"[ODOO_PRODUCT]: Creando picking")
-        picking_data = self.create_product_picking(product_info, picking_qty)
+        picking_data = self.create_product_picking(
+            product_info,
+            picking_qty,
+            source_location_id=picking_source_location_id if picking_source_location_id is not None else location_dest_id,
+            destination_location_id=picking_destination_location_id,
+            picking_type_id=picking_type_id,
+        )
         if picking_data["status"] == "error":
             production_order_data["status"] = "error"
             production_order_data["message"] = f"Error al crear el picking"


### PR DESCRIPTION
## Summary
- Parametrize all hardcoded `stock.location` ids in `OdooProduct.create_single_production_order` and `OdooProduct.create_product_picking`.
- Defaults preserve existing behavior (location_dest_id=8, picking_destination_location_id=20, picking_type_id=5) so other consumers are unaffected.
- When `picking_source_location_id` is omitted, the internal picking source defaults to the MO `location_dest_id` to keep the flow consistent (picking pulls from where the MO just produced).
- Bump `odoo-api` version to **3.4.0**.

## Motivation
`deploy-juan` needs to direct production orders to `JS/Producto Terminado` (id=57) instead of `JS/Tienda` (id=8). Rather than hardcoding the new id in the library, the call sites are now parametrized so consumers control the destination.

## Test plan
- [ ] Existing callers without the new kwargs continue to behave identically (defaults match previous hardcodes).
- [ ] New caller in `deploy-juan` will pass `location_dest_id=57` (and matching picking source) and create MO + internal picking at the correct locations in Odoo test.
- [ ] After merge, tag `v3.4.0` (or the equivalent monorepo tag pattern) so consumers can pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)